### PR TITLE
Added support for developing plugins with Java and updated ASM to 9.6 to support Java 21

### DIFF
--- a/proxy/build.gradle.kts
+++ b/proxy/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
   implementation(group = "org.lanternpowered", name = "lmbda", version = "3.0.0-SNAPSHOT")
 
   // ASM
-  implementation(group = "org.ow2.asm", name = "asm", version = "9.4")
+  implementation(group = "org.ow2.asm", name = "asm", version = "9.6")
 
   // Plugins
   implementation(group = "org.spongepowered", name = "plugin-spi", version = "0.3.0")

--- a/proxy/src/main/kotlin/org/lanternpowered/terre/plugin/Inject.kt
+++ b/proxy/src/main/kotlin/org/lanternpowered/terre/plugin/Inject.kt
@@ -22,6 +22,7 @@ inline fun <reified T> Any.inject(): T {
   return doInject(typeOf<T>()) as T
 }
 
+
 /**
  * Gets a [ReadOnlyProperty] that lazily injects the value.
  */

--- a/proxy/src/main/kotlin/org/lanternpowered/terre/plugin/JavaWrapper.kt
+++ b/proxy/src/main/kotlin/org/lanternpowered/terre/plugin/JavaWrapper.kt
@@ -1,0 +1,45 @@
+/*
+ * Terre
+ *
+ * Copyright (c) LanternPowered <https://www.lanternpowered.org>
+ * Copyright (c) contributors
+ *
+ * This work is licensed under the terms of the MIT License (MIT). For
+ * a copy, see 'LICENSE.txt' or <https://opensource.org/licenses/MIT>.
+ */
+package org.lanternpowered.terre.plugin
+
+import org.lanternpowered.terre.config.ConfigDirectory
+import org.lanternpowered.terre.logger.Logger
+import java.lang.String
+
+/**
+ * A wrapper to Inject.kt for Java
+ * **/
+@Suppress("unused")
+
+open class JavaWrapper {
+  private val logger = inject<Logger>();
+  fun getLogger() : Logger {
+    return inject<Logger>()
+  }
+  fun getConfigDirectory(): ConfigDirectory {
+    return inject<ConfigDirectory>()
+  }
+  fun info(msg: String) {
+    val s:kotlin.String =  msg as kotlin.String;
+    logger.info(s)
+  }
+  fun warn(msg: String) {
+    val s:kotlin.String =  msg as kotlin.String;
+    logger.warn(s)
+  }
+  fun error(msg: String) {
+    val s:kotlin.String =  msg as kotlin.String;
+    logger.error(s)
+  }
+  fun debug(msg: String) {
+    val s:kotlin.String =  msg as kotlin.String;
+    logger.debug(s)
+  }
+}

--- a/proxy/src/main/kotlin/org/lanternpowered/terre/plugin/Plugin.kt
+++ b/proxy/src/main/kotlin/org/lanternpowered/terre/plugin/Plugin.kt
@@ -9,17 +9,13 @@
  */
 package org.lanternpowered.terre.plugin
 
-import org.lanternpowered.terre.util.`use named arguments`
-
 /**
  * An annotation to mark plugin classes or objects.
  *
  * @property id The id, can only contain a-z, 0-9, - and _
  */
-@Suppress("unused")
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
-annotation class Plugin(
-  vararg val `use named arguments`: `use named arguments`,
+annotation class Plugin (
   val id: String
 )


### PR DESCRIPTION
Simply extend the JavaWrapper in a class annotated with @Plugin to get access to the Logger and ConfigDirectory.